### PR TITLE
Adjust screensaver interval to five minutes

### DIFF
--- a/components/SaverScene.brs
+++ b/components/SaverScene.brs
@@ -7,7 +7,7 @@ sub init()
   m.hint = m.top.findNode("hint")
 
   m.previewDuration = 5.0       ' seconds
-  m.saverDuration   = 180.0     ' 3 minutes per latest requirements
+  m.saverDuration   = 300.0     ' 5 minutes per latest requirements
   m.defaultUri      = "pkg:/images/offline/default.jpg"
   m.previewHint     = "Preview — Up/Down to cycle  •  Back to exit"
 


### PR DESCRIPTION
## Summary
- update the screensaver timer interval to five minutes so the saver advances less frequently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d425a473808323aaa09b1bce9221bc