### PR TITLE
Stabilize screensaver preview and settings

### DIFF
--- a/components/SaverScene.brs
+++ b/components/SaverScene.brs
@@ -6,9 +6,8 @@ sub init()
   m.tick = m.top.findNode("tick")
   m.hint = m.top.findNode("hint")
 
-  m.previewDuration = 5.0       ' seconds
-  m.saverDuration   = 300.0     ' 5 minutes per project requirements
-  m.saverDuration   = 300.0     ' 5 minutes per latest requirements
+  m.previewDuration = 5.0        ' seconds
+  m.saverDuration   = 300.0      ' 5 minutes per product requirements
   m.defaultUri      = "pkg:/images/offline/default.jpg"
   m.previewHint     = "Preview — Up/Down to cycle  •  Back to exit"
 
@@ -50,20 +49,6 @@ sub onModeChanged()
   m.tick.control = "stop"
   StopFeedTask()
 
-
-  m.mode = nextMode
-  m.tick.control = "stop"
-  StopFeedTask()
-
-
-  if nextMode = m.mode then return
-
-  print "SaverScene onModeChanged -> " ; nextMode
-
-  m.mode = nextMode
-  m.tick.control = "stop"
-  StopFeedTask()
-
   if m.mode = "preview" then
     ConfigurePreview()
   else
@@ -78,10 +63,8 @@ sub ConfigurePreview()
   m.offlineUris = OfflineAllUris()
   m.uris = CloneArray(m.offlineUris)
   if m.uris.count() = 0 then m.uris.push(m.defaultUri)
+  m.idx = 0
   SetImage(0)
-  m.tick.control = "start"
-end sub
-
   m.tick.control = "start"
 end sub
 
@@ -92,21 +75,7 @@ sub ConfigureScreensaver()
   m.offlineUris = OfflineForSaved()
   m.uris = CloneArray(m.offlineUris)
   if m.uris.count() = 0 then m.uris.push(m.defaultUri)
-  SetImage(0)
-  StartFeedTask()
-  m.tick.control = "start"
-end sub
-
-  m.tick.control = "start"
-end sub
-
-sub ConfigureScreensaver()
-  m.hint.text = ""
-  m.hint.visible = false
-  m.tick.duration = m.saverDuration
-  m.offlineUris = OfflineForSaved()
-  m.uris = CloneArray(m.offlineUris)
-  if m.uris.count() = 0 then m.uris.push(m.defaultUri)
+  m.idx = 0
   SetImage(0)
   StartFeedTask()
   m.tick.control = "start"
@@ -193,17 +162,10 @@ end function
 
 ' Launch the background task that fetches the GitHub index.json
 sub StartFeedTask()
+  StopFeedTask()
+
   reg = CreateObject("roRegistrySection", "FaithSaver")
   sel = reg.Read("category")
-  if sel = invalid then sel = ""
-  sel = LCase(sel)
-
-  StopFeedTask()
-
-  actual = NormalizeSavedCategory(sel)
-
-  StopFeedTask()
-
   actual = NormalizeSavedCategory(sel)
 
   m.feed = CreateObject("roSGNode", "ImageFeedTask")
@@ -211,11 +173,6 @@ sub StartFeedTask()
   m.feed.observeField("result", "onFeed")
   m.top.appendChild(m.feed)
   print "SaverScene StartFeedTask -> saved=" ; sel ; " actual=" ; actual
-  m.feed = CreateObject("roSGNode","ImageFeedTask")
-  m.feed.category = sel
-  m.feed.observeField("result","onFeed")
-  m.top.appendChild(m.feed)
-  print "SaverScene StartFeedTask -> category="; sel
   m.feed.control = "run"
 end sub
 
@@ -236,7 +193,6 @@ sub onFeed()
       print "SaverScene onFeed -> swapping to remote URIs count=" ; m.uris.count()
       StopFeedTask()
       return
-      print "SaverScene onFeed -> swapping to remote URIs count="; m.uris.count()
     end if
   end if
 
@@ -261,6 +217,11 @@ end function
 
 ' Display image at index i (wraps around)
 sub SetImage(i as Integer)
+  if m.img = invalid then
+    print "SaverScene SetImage -> Poster node missing"
+    return
+  end if
+
   if m.uris = invalid then return
   total = m.uris.count()
   if total = 0 then return
@@ -276,91 +237,8 @@ sub SetImage(i as Integer)
   attempts = 0
   idx = i
   while attempts < total
-    uri = m.uris[idx]
-    if uri <> invalid and uri <> "" then
-      m.idx = idx
-      print "SaverScene SetImage -> idx=" ; m.idx ; " uri=" ; uri
-      m.img.visible = true
-      m.img.uri = uri
-      return
-    end if
-    print "SaverScene SetImage -> skipping empty uri at index=" ; idx
-    idx = (idx + 1) mod total
-    attempts = attempts + 1
-  end while
-
-  while i < 0
-    i = i + total
-  end while
-
-  if total > 0 then
-    i = i mod total
-  end if
-
-  attempts = 0
-  idx = i
-  while attempts < total
-    uri = m.uris[idx]
-    if uri <> invalid and uri <> "" then
-      m.idx = idx
-      print "SaverScene SetImage -> idx=" ; m.idx ; " uri=" ; uri
-      m.img.visible = true
-      m.img.uri = uri
-      return
-    end if
-    print "SaverScene SetImage -> skipping empty uri at index=" ; idx
-    idx = (idx + 1) mod total
-    attempts = attempts + 1
-  end while
-
-  while i < 0
-    i = i + total
-  end while
-
-  if total > 0 then
-    i = i mod total
-  end if
-
-  attempts = 0
-  idx = i
-  while attempts < total
-    uri = m.uris[idx]
-    if uri <> invalid and uri <> "" then
-      m.idx = idx
-      print "SaverScene SetImage -> idx=" ; m.idx ; " uri=" ; uri
-      m.img.visible = true
-      m.img.uri = uri
-      return
-    end if
-    print "SaverScene SetImage -> skipping empty uri at index=" ; idx
-    idx = (idx + 1) mod total
-    attempts = attempts + 1
-  end while
-
-
-  while i < 0
-    i = i + total
-  end while
-
-  if total > 0 then
-    i = i mod total
-  end if
-
-  while i < 0
-    i = i + total
-  end while
-
-  if total > 0 then
-    i = i mod total
-  end if
-
-  m.idx = i
-
-  attempts = 0
-  idx = i
-  while attempts < total
-    uri = m.uris[idx]
-    if uri <> invalid and uri <> "" then
+    uri = NormalizeUriString(m.uris[idx])
+    if uri <> "" then
       m.idx = idx
       print "SaverScene SetImage -> idx=" ; m.idx ; " uri=" ; uri
       m.img.visible = true
@@ -373,6 +251,9 @@ sub SetImage(i as Integer)
   end while
 
   print "SaverScene SetImage -> no valid URIs available"
+  m.img.visible = true
+  m.img.uri = m.defaultUri
+  m.idx = 0
 end sub
 
 ' Skip to next image if a uri fails to load
@@ -410,14 +291,9 @@ function onKeyEvent(key as String, press as Boolean) as Boolean
     end if
     return false
   else if m.mode = "screensaver" then
-    if lower = "back" then
-      m.top.close = true
-      return true
-    else if lower = "up" or lower = "down" or lower = "ok" then
-      ' Consume navigation keys in saver mode so the system does not treat the session like preview
-      return true
-    end if
-    return false
+    ' Any key press should dismiss the saver and return control to Roku
+    m.top.close = true
+    return true
   end if
 
   return false
@@ -469,6 +345,31 @@ end function
 
 function NormalizeUriString(val as Dynamic) as String
   if type(val) <> "roString" then return ""
-  trimmed = LTrim(RTrim(val))
-  return trimmed
+  return TrimWhitespace(val)
+end function
+
+function TrimWhitespace(input as String) as String
+  if input = invalid then return ""
+
+  text = input
+  total = Len(text)
+  if total <= 0 then return ""
+
+  startIndex = 0
+  while startIndex < total
+    ch = Asc(Mid(text, startIndex + 1, 1))
+    if ch > 32 then exit while
+    startIndex = startIndex + 1
+  end while
+
+  endIndex = total - 1
+  while endIndex >= startIndex
+    ch = Asc(Mid(text, endIndex + 1, 1))
+    if ch > 32 then exit while
+    endIndex = endIndex - 1
+  end while
+
+  if endIndex < startIndex then return ""
+
+  return Mid(text, startIndex + 1, endIndex - startIndex + 1)
 end function

--- a/components/SettingsScene.brs
+++ b/components/SettingsScene.brs
@@ -1,16 +1,26 @@
 ' SettingsScene — plain labels + custom highlight (RGBA colors). No roFileSystem.
 
 sub init()
-    m.bg    = m.top.findNode("bg")
-    m.menu  = m.top.findNode("menu")
-    m.title = m.top.findNode("title")
-    m.about = m.top.findNode("about")
+    m.bg         = m.top.findNode("bg")
+    m.menu       = m.top.findNode("menu")
+    m.title      = m.top.findNode("title")
+    m.about      = m.top.findNode("about")
+    m.aboutText  = m.top.findNode("aboutText")
+    m.aboutTitle = m.top.findNode("aboutTitle")
     m.aboutVisible = false
+    m.aboutLoaded  = false
 
     ' RGBA colors (0xRRGGBBAA)
     m.colorNavy  = &h103A57FF   ' navy #103A57, fully opaque
     m.colorWhite = &hFFFFFFFF   ' white
     m.colorBlack = &h000000FF   ' black
+
+    if m.aboutText <> invalid then
+        m.aboutText.textVertAlign = "top"
+        m.aboutText.textHorizAlign = "left"
+        m.aboutText.textAttrs = { color: m.colorBlack, fontSize: 26 }
+        m.aboutText.maxLines = 0
+    end if
 
     ' Layout
     m.rowH  = 72
@@ -18,6 +28,11 @@ sub init()
     m.textX = 16
 
     print "SettingsScene.init"
+
+    if m.bg <> invalid then
+        m.bg.uri = "pkg:/images/FaithSaver-Splash-1920x1080.jpg"
+        m.bg.loadDisplayMode = "scaleToFill"
+    end if
 
     BuildOptions()
 
@@ -152,6 +167,17 @@ sub Paint()
 end sub
 
 sub ShowAbout()
+    if not m.aboutLoaded then
+        aboutText = LoadAboutText()
+        if m.aboutTitle <> invalid then
+            m.aboutTitle.text = "About FaithSaver"
+        end if
+        if m.aboutText <> invalid then
+            m.aboutText.text = aboutText
+        end if
+        m.aboutLoaded = true
+    end if
+
     if m.about <> invalid then
         m.about.visible = true
     end if
@@ -212,4 +238,16 @@ function onKeyEvent(key as String, press as Boolean) as Boolean
     end if
 
     return false
+end function
+
+function LoadAboutText() as String
+    path = "pkg:/README.md"
+    content = ReadAsciiFile(path)
+    if type(content) = "roString" and content <> "" then
+        clean = Replace(content, Chr(13) + Chr(10), Chr(10))
+        clean = Replace(clean, Chr(13), Chr(10))
+        return clean
+    end if
+
+    return "FaithSaver Screensaver\n\nREADME could not be loaded from " + path + "."
 end function

--- a/components/SettingsScene.xml
+++ b/components/SettingsScene.xml
@@ -46,14 +46,20 @@
         color="0xFFFFFFFF"
         opacity="0.94" />
       <Label
-        translation="[440,280]"
+        id="aboutTitle"
+        translation="[440,260]"
         width="1040"
-        height="560"
-        wrap="true"
-        horizAlign="center"
+        height="40"
+        horizAlign="left"
         vertAlign="top"
         color="0x000000FF"
-        text="FaithSaver Screensaver\n\nVersion info and credits will appear here in a future update. Press Back or OK to return." />
+        text="About FaithSaver" />
+      <ScrollableText
+        id="aboutText"
+        translation="[440,320]"
+        width="1040"
+        height="520"
+        text="Loading README..." />
     </Group>
   </children>
 


### PR DESCRIPTION
## Summary
- prevent runtime crashes by replacing BrightScript trim calls with a safe manual implementation and keeping preview/saver timers aligned to the 5-minute cadence
- ensure the settings scene loads reliably with the correct splash background and expose an About overlay that surfaces the packaged README content
- keep screensaver input handling predictable by exiting on any key press and guaranteeing preview/saver image arrays always normalize URIs before display

## Testing
- not run (BrightScript runtime not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68d43a21a35c83238b1c5c07a69d1d60