### PR TITLE
Fix settings scene event loop and styling

### DIFF
--- a/components/SettingsScene.brs
+++ b/components/SettingsScene.brs
@@ -3,17 +3,19 @@ sub init()
     m.top.setFocus(true)
     m.list = m.top.findNode("list")
 
-    ' White text, Navy highlight requirements
-    ' (Use built-in fields for readability; keep it simple and consistent.)
-    m.list.itemTextColor        = "0xFFFFFFFF" ' white
-    m.list.focusBitmapBlendColor = "0x001F3FFF" ' navy-ish focus bar (ARGB -> 0xAARRGGBB; here AA=00 means we rely on built-in opacity)
-    m.list.focusBitmapUri       = ""           ' default highlight bar with our blend color
+    if m.list <> invalid then
+        ' White text, Navy highlight requirements
+        ' Use blend color to tint the default highlight bar.
+        m.list.itemTextColor         = "0xFFFFFFFF" ' white
+        m.list.focusBitmapBlendColor = "0xFF001F3F" ' opaque navy
+        m.list.focusBitmapUri        = ""            ' default highlight bar with our blend color
 
-    ' minimal example items
-    m.list.content = CreateSettingsContent()
+        ' minimal example items
+        m.list.content = CreateSettingsContent()
 
-    ' ensure the list can receive keys
-    m.list.setFocus(true)
+        ' ensure the list can receive keys
+        m.list.setFocus(true)
+    end if
 end sub
 
 function CreateSettingsContent() as object
@@ -39,13 +41,15 @@ end function
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
+    key = LCase(key)
+
     if key = "back" or key = "home" then
         ' Signal our parent loop to exit settings cleanly
         m.top.closeRequested = true
         return true
     end if
 
-    if key = "OK"
+    if key = "ok"
         if m.list <> invalid then
             idx = m.list.itemFocused
             ' Example: last item exits

--- a/source/main.brs
+++ b/source/main.brs
@@ -38,6 +38,11 @@ sub RunScreenSaverSettings()
     screen.SetMessagePort(m.port)
 
     scene = screen.CreateScene("SettingsScene")
+    if scene <> invalid then
+        scene.SetFocus(true)
+        scene.ObserveField("closeRequested", m.port)
+    end if
+
     screen.Show()
 
     ' wait until user exits
@@ -46,7 +51,8 @@ sub RunScreenSaverSettings()
         if type(msg) = "roSGScreenEvent" then
             if msg.isScreenClosed() then exit while
         else if type(msg) = "roSGNodeEvent" then
-            if msg.GetNode() <> invalid and msg.GetField() = "closeRequested" and msg.GetData() = true
+            node = msg.GetNode()
+            if node <> invalid and node = scene and msg.GetField() = "closeRequested" and msg.GetData() = true then
                 exit while
             end if
         end if


### PR DESCRIPTION
## Summary
- keep the settings screen alive by observing the closeRequested field and waiting for user exit events
- set focus and style on the settings LabelList so it uses white text with a navy highlight bar

## Testing
- not run (roku hardware required)


------
https://chatgpt.com/codex/tasks/task_b_68e6b28651208323b8afde0a77be5562