### PR TITLE
Stabilize settings event loop and list focus

### DIFF
--- a/components/SettingsScene.brs
+++ b/components/SettingsScene.brs
@@ -3,27 +3,28 @@ sub init()
     m.top.setFocus(true)
     m.list = m.top.findNode("list")
 
-    ' White text, Navy highlight requirements
-    ' (Use built-in fields for readability; keep it simple and consistent.)
-    m.list.itemTextColor        = "0xFFFFFFFF" ' white
-    m.list.focusBitmapBlendColor = "0x001F3FFF" ' navy-ish focus bar (ARGB -> 0xAARRGGBB; here AA=00 means we rely on built-in opacity)
-    m.list.focusBitmapUri       = ""           ' default highlight bar with our blend color
+    if m.list <> invalid then
+        ' White text, Navy highlight requirements
+        m.list.itemTextColor         = "0xFFFFFFFF" ' white
+        m.list.focusBitmapUri        = ""            ' ensure blend color applies
+        m.list.focusBitmapBlendColor = "0xFF001F3F" ' opaque navy
 
-    ' minimal example items
-    m.list.content = CreateSettingsContent()
+        ' populate list content
+        m.list.content = CreateSettingsContent()
 
-    ' ensure the list can receive keys
-    m.list.setFocus(true)
+        ' give focus to the list so keys are handled
+        m.list.setFocus(true)
+    end if
 end sub
 
 function CreateSettingsContent() as object
     rows = [
-        { title: "Theme: Classic" }
-        { title: "Show Verse: On" }
-        { title: "Rotation Speed: Normal" }
-        { title: "Clock: Off" }
-        { title: "Reset to Defaults" }
-        { title: "About FaithSaver" }
+        { title: "Theme: Classic" },
+        { title: "Show Verse: On" },
+        { title: "Rotation Speed: Normal" },
+        { title: "Clock: Off" },
+        { title: "Reset to Defaults" },
+        { title: "About FaithSaver" },
         { title: "Back" }
     ]
 
@@ -39,19 +40,24 @@ end function
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
+    key = LCase(key)
+
     if key = "back" or key = "home" then
         ' Signal our parent loop to exit settings cleanly
         m.top.closeRequested = true
         return true
     end if
 
-    if key = "OK"
+    if key = "ok"
         if m.list <> invalid then
             idx = m.list.itemFocused
-            ' Example: last item exits
-            if idx = m.list.content.GetChildCount() - 1
-                m.top.closeRequested = true
-                return true
+            content = m.list.content
+            if content <> invalid then
+                backIndex = content.GetChildCount() - 1
+                if idx = backIndex then
+                    m.top.closeRequested = true
+                    return true
+                end if
             end if
         end if
     end if

--- a/source/main.brs
+++ b/source/main.brs
@@ -34,20 +34,30 @@ end sub
 sub RunScreenSaverSettings()
     ' dedicated settings screen that blocks until Back/Home
     screen = CreateObject("roSGScreen")
-    m.port = CreateObject("roMessagePort")
-    screen.SetMessagePort(m.port)
+    port = CreateObject("roMessagePort")
+    screen.SetMessagePort(port)
 
     scene = screen.CreateScene("SettingsScene")
+    if scene <> invalid then
+        scene.ObserveField("closeRequested", port)
+    end if
+
     screen.Show()
+
+    if scene <> invalid then
+        scene.SetFocus(true)
+    end if
 
     ' wait until user exits
     while true
-        msg = wait(0, m.port)
-        if type(msg) = "roSGScreenEvent" then
+        msg = wait(0, port)
+        if msg = invalid then
+            ' nothing to do
+        else if type(msg) = "roSGScreenEvent" then
             if msg.isScreenClosed() then exit while
         else if type(msg) = "roSGNodeEvent" then
-            if msg.GetNode() <> invalid and msg.GetField() = "closeRequested" and msg.GetData() = true
-                exit while
+            if msg.GetNode() = scene and msg.GetField() = "closeRequested" then
+                if msg.GetData() = true then exit while
             end if
         end if
     end while
@@ -93,5 +103,6 @@ end sub
 
 ' Roku calls main for legacy. Keep minimal.
 sub main(args as dynamic)
+    if args <> invalid then : end if ' suppress unused warning from compiler
     RunUserInterface()
 end sub


### PR DESCRIPTION
## Summary
- keep the settings screen alive by using a dedicated message port and waiting on the closeRequested field until the user exits
- populate and focus the settings list with explicit content nodes and the navy highlight styling so OK/Back can exit properly

## Testing
- not run (roku hardware required)

------
https://chatgpt.com/codex/tasks/task_b_68e6b28651208323b8afde0a77be5562