### PR TITLE
Keep settings scene running until user exits

### DIFF
--- a/components/SettingsScene.brs
+++ b/components/SettingsScene.brs
@@ -1,29 +1,31 @@
 ' ===== SettingsScene.brs =====
 sub init()
+    m.top.closeRequested = false
     m.top.setFocus(true)
     m.list = m.top.findNode("list")
 
-    ' White text, Navy highlight requirements
-    ' (Use built-in fields for readability; keep it simple and consistent.)
-    m.list.itemTextColor        = "0xFFFFFFFF" ' white
-    m.list.focusBitmapBlendColor = "0x001F3FFF" ' navy-ish focus bar (ARGB -> 0xAARRGGBB; here AA=00 means we rely on built-in opacity)
-    m.list.focusBitmapUri       = ""           ' default highlight bar with our blend color
+    if m.list <> invalid then
+        ' White text, Navy highlight requirements
+        m.list.itemTextColor         = "0xFFFFFFFF" ' white
+        m.list.focusBitmapUri        = ""            ' ensure blend color applies
+        m.list.focusBitmapBlendColor = "0xFF001F3F" ' opaque navy
 
-    ' minimal example items
-    m.list.content = CreateSettingsContent()
+        ' populate list content
+        m.list.content = CreateSettingsContent()
 
-    ' ensure the list can receive keys
-    m.list.setFocus(true)
+        ' give focus to the list so keys are handled
+        m.list.setFocus(true)
+    end if
 end sub
 
 function CreateSettingsContent() as object
     rows = [
-        { title: "Theme: Classic" }
-        { title: "Show Verse: On" }
-        { title: "Rotation Speed: Normal" }
-        { title: "Clock: Off" }
-        { title: "Reset to Defaults" }
-        { title: "About FaithSaver" }
+        { title: "Theme: Classic" },
+        { title: "Show Verse: On" },
+        { title: "Rotation Speed: Normal" },
+        { title: "Clock: Off" },
+        { title: "Reset to Defaults" },
+        { title: "About FaithSaver" },
         { title: "Back" }
     ]
 
@@ -39,19 +41,24 @@ end function
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
 
+    key = LCase(key)
+
     if key = "back" or key = "home" then
         ' Signal our parent loop to exit settings cleanly
         m.top.closeRequested = true
         return true
     end if
 
-    if key = "OK"
+    if key = "ok"
         if m.list <> invalid then
             idx = m.list.itemFocused
-            ' Example: last item exits
-            if idx = m.list.content.GetChildCount() - 1
-                m.top.closeRequested = true
-                return true
+            content = m.list.content
+            if content <> invalid then
+                backIndex = content.GetChildCount() - 1
+                if idx = backIndex then
+                    m.top.closeRequested = true
+                    return true
+                end if
             end if
         end if
     end if

--- a/source/main.brs
+++ b/source/main.brs
@@ -34,25 +34,31 @@ end sub
 sub RunScreenSaverSettings()
     ' dedicated settings screen that blocks until Back/Home
     screen = CreateObject("roSGScreen")
-    m.port = CreateObject("roMessagePort")
-    screen.SetMessagePort(m.port)
+    port = CreateObject("roMessagePort")
+    screen.SetMessagePort(port)
 
     scene = screen.CreateScene("SettingsScene")
+    if scene = invalid then return
+
+    scene.ObserveField("closeRequested", port)
+
     screen.Show()
+    scene.control = "RUN"
+    scene.SetFocus(true)
 
     ' wait until user exits
     while true
-        msg = wait(0, m.port)
+        msg = wait(0, port)
         if type(msg) = "roSGScreenEvent" then
             if msg.isScreenClosed() then exit while
         else if type(msg) = "roSGNodeEvent" then
-            if msg.GetNode() <> invalid and msg.GetField() = "closeRequested" and msg.GetData() = true
+            if msg.GetField() = "closeRequested" and msg.GetData() = true then
                 exit while
             end if
         end if
     end while
 
-    ' screen auto-closes on exit of sub
+    screen.Close()
 end sub
 
 ' --- dev launcher / channel launch router ---
@@ -93,5 +99,6 @@ end sub
 
 ' Roku calls main for legacy. Keep minimal.
 sub main(args as dynamic)
+    if args <> invalid then : end if ' suppress unused warning from compiler
     RunUserInterface()
 end sub


### PR DESCRIPTION
## Summary
- ensure the settings entrypoint keeps the scene running by starting the SceneGraph control loop and waiting for the closeRequested flag
- reset the closeRequested field on scene init so Back/Home exits work reliably when returning to the settings menu

## Testing
- not run (roku hardware required)


------
https://chatgpt.com/codex/tasks/task_b_68e6b28651208323b8afde0a77be5562