### PR TITLE
Fix settings list focus visuals and persistence

### DIFF
--- a/components/SettingsRow.brs
+++ b/components/SettingsRow.brs
@@ -3,6 +3,7 @@ sub init()
   m.lbl = m.top.findNode("lbl")
   m.NAVY  = &hFF083554
   m.WHITE = &hFFFFFFFF
+
   if m.lbl <> invalid then m.lbl.color = m.NAVY
   if m.bar <> invalid then m.bar.visible = false
   print "[FS][SettingsRow] init bar="; (m.bar <> invalid); " lbl="; (m.lbl <> invalid)
@@ -10,24 +11,33 @@ end sub
 
 sub onContent()
   c = m.top.itemContent
-  if c <> invalid and c.DoesExist("title")
-    m.lbl.text = c.title
-  else
-    m.lbl.text = ""
+  title = ""
+  if c <> invalid and c.DoesExist("title") then
+    title = c.title
   end if
-  if m.lbl <> invalid then m.lbl.color = m.NAVY
+
+  if m.lbl <> invalid then
+    m.lbl.text = title
+    m.lbl.color = m.NAVY
+  end if
+
   if m.bar <> invalid then m.bar.visible = m.top.itemHasFocus
-  print "[FS][SettingsRow] onContent title='"; m.lbl.text; "'"
+  print "[FS][SettingsRow] onContent title='"; title; "'"
 end sub
 
 sub onFocus()
-  if m.top.itemHasFocus then
-    if m.bar <> invalid then m.bar.visible = true
-    if m.lbl <> invalid then m.lbl.color = m.WHITE
+  hasFocus = m.top.itemHasFocus
+  if m.bar <> invalid then m.bar.visible = hasFocus
+  if m.lbl <> invalid then
+    if hasFocus then
+      m.lbl.color = m.WHITE
+    else
+      m.lbl.color = m.NAVY
+    end if
+  end if
+  if hasFocus then
     print "[FS][SettingsRow] onFocus focus=true"
   else
-    if m.bar <> invalid then m.bar.visible = false
-    if m.lbl <> invalid then m.lbl.color = m.NAVY
     print "[FS][SettingsRow] onFocus focus=false"
   end if
 end sub

--- a/components/SettingsRow.xml
+++ b/components/SettingsRow.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="SettingsRow" extends="Group">
   <interface>
-    <field id="itemContent"  type="node"    onChange="onContent" />
-    <field id="itemHasFocus" type="boolean" onChange="onFocus"   />
+    <field id="itemContent" type="node" onChange="onContent" />
+    <field id="itemHasFocus" type="boolean" onChange="onFocus" />
   </interface>
 
   <children>
-    <Rectangle id="bar" width="1800" height="60" color="0xFF083554" visible="false" />
-    <Label id="lbl"
-           translation="[20,0]"
-           width="1760" height="60"
-           horizAlign="left" vertAlign="center"
-           color="0xFF083554"
-           text="" />
+    <Rectangle
+      id="bar"
+      width="1800"
+      height="60"
+      color="0xFF083554"
+      visible="false" />
+
+    <Label
+      id="lbl"
+      width="1760"
+      height="60"
+      translation="[20,0]"
+      horizAlign="left"
+      vertAlign="center"
+      color="0xFF083554" />
   </children>
 
   <script type="text/brightscript" uri="pkg:/components/SettingsRow.brs" />

--- a/components/SettingsScene.brs
+++ b/components/SettingsScene.brs
@@ -5,17 +5,20 @@ sub init()
   m.header = m.top.findNode("header")
   m.list   = m.top.findNode("list")
 
-  ' Ensure spacing & use our own focus visuals (disable Roku pink)
+  print "[FS][SettingsScene] init: bg="; (m.bg <> invalid); ", scrim="; (m.scrim <> invalid); ", header="; (m.header <> invalid); ", list="; (m.list <> invalid)
+
   if m.list <> invalid then
     m.list.itemSpacing = [0, 8]
     m.list.AddReplace("drawFocusFeedback", false)
     m.list.focusable = true
     m.list.setFocus(true)
+    print "[FS][SettingsScene] list.itemSpacing="; m.list.itemSpacing; ", drawFocusFeedback="; m.list.drawFocusFeedback
   end if
-  print "[FS][SettingsScene] list.itemSpacing="; m.list.itemSpacing; ", drawFocusFeedback="; getFieldSafe(m.list, "drawFocusFeedback")
 
-  ' Display strings (capitalized)
-  m.categories = [ "Scenery","Space","Spring","Summer","Textures","Winter","Seasonal","Animals","Fall","Geology" ]
+  m.categories = [
+    "Scenery","Space","Spring","Summer","Textures",
+    "Winter","Seasonal","Animals","Fall","Geology"
+  ]
 
   content = CreateObject("roSGNode", "ContentNode")
   for each t in m.categories
@@ -23,26 +26,24 @@ sub init()
     n.title = t
     content.appendChild(n)
   end for
-  m.list.content = content
-  print "[FS][SettingsScene] content assigned (count= "; m.categories.count(); ")"
+  if m.list <> invalid then m.list.content = content
+  print "[FS][SettingsScene] content assigned (count="; m.categories.count(); ")"
 
-  ' Restore selection
-  cur = ReadCategory()
-  if cur = "" then cur = "Scenery"
-  idx = findIndexCI(m.categories, cur)
+  stored = ReadCategory()
+  if stored = "" then stored = "Scenery"
+  idx = findIndexCI(m.categories, stored)
   if idx < 0 then idx = 0
-  m.list.jumpToItem = idx
 
+  if m.list <> invalid then m.list.jumpToItem = idx
   updateHeader(idx, m.categories[idx])
 
-  ' React to focus change
-  m.list.ObserveField("itemFocused", "onListFocusChanged")
-
-  print "[FS][SettingsScene] init done; selected="; m.categories[idx]; " startIdx="; idx
+  if m.list <> invalid then m.list.ObserveField("itemFocused", "onListFocusChanged")
 end sub
 
 sub onListFocusChanged()
+  if m.list = invalid then return
   i = m.list.itemFocused
+  print "[FS][SettingsScene] itemFocused -> "; i
   if i < 0 then return
   updateHeader(i, getSelectedCurrent())
 end sub
@@ -54,12 +55,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
     m.top.closeRequested = true
     return true
   else if key = "ok" then
-    i = m.list.itemFocused : if i < 0 then i = 0
+    if m.list = invalid then return false
+    i = m.list.itemFocused
+    if i < 0 then i = 0
     sel = m.categories[i]
     SaveCategory(sel)
-    print "[FS][SettingsScene][REG] write 'category'="; lcase(sel); " flush=true"
     updateHeader(i, sel)
-    print "[FS][SettingsScene] saved selection="; lcase(sel); " (idx="; i; ")"
     return true
   end if
 
@@ -68,16 +69,21 @@ end function
 
 ' ---- helpers ----
 function getSelectedCurrent() as string
+  if m.categories = invalid then return ""
   v = ReadCategory()
-  if v = "" then return ""
+  if v = "" then
+    if m.categories.count() > 0 then return m.categories[0]
+    return ""
+  end if
   i = findIndexCI(m.categories, v)
   if i >= 0 then return m.categories[i]
   return v
 end function
 
 function findIndexCI(arr as object, val as string) as integer
+  if arr = invalid then return -1
   lv = lcase(val)
-  for i = 0 to arr.count()-1
+  for i = 0 to arr.count() - 1
     if lcase(arr[i]) = lv then return i
   end for
   return -1
@@ -85,25 +91,33 @@ end function
 
 sub updateHeader(focusedIdx as integer, selectedVal as string)
   curr = "(none)"
-  if selectedVal <> "" then curr = selectedVal
+  if selectedVal <> "" then
+    curr = selectedVal
+  end if
   if m.header <> invalid then m.header.text = "Current: " + curr
-  print "[FS][SettingsScene] header='"; m.header.text; "'"
+  if m.header <> invalid then
+    print "[FS][SettingsScene] header='"; m.header.text; "'"
+  else
+    print "[FS][SettingsScene] header update skipped (header invalid)"
+  end if
 end sub
 
 function ReadCategory() as string
   sec = CreateObject("roRegistrySection", "FaithSaver")
   if sec = invalid then return ""
-  v = sec.Read("category") : if v = invalid then return ""
+  v = sec.Read("category")
+  if v = invalid then return ""
   return v
 end function
 
 sub SaveCategory(cat as string)
+  lc = lcase(cat)
   sec = CreateObject("roRegistrySection", "FaithSaver")
-  sec.Write("category", lcase(cat))
-  sec.Flush()
+  if sec <> invalid then
+    sec.Write("category", lc)
+    sec.Flush()
+    print "[FS][SettingsScene][REG] write 'category'="; lc; " flush=true"
+  else
+    print "[FS][SettingsScene][REG] write 'category'="; lc; " flush=false (section invalid)"
+  end if
 end sub
-
-function getFieldSafe(n as object, f as string) as dynamic
-  if n <> invalid and n.DoesExist(f) then return n[f]
-  return invalid
-end function

--- a/components/SettingsScene.xml
+++ b/components/SettingsScene.xml
@@ -15,7 +15,7 @@
 
     <Rectangle
       id="scrim"
-      color="0x33000000"
+      color="0x40000000"
       width="1920"
       height="1080"
       translation="[0,0]" />


### PR DESCRIPTION
## Summary
- update SettingsScene layout and controller to disable default Roku focus feedback, log state, and persist the selected category in the registry
- ensure the header reflects the saved category, defaulting to Scenery when none is stored, and log focus/registry actions for debugging
- style SettingsRow items to render a navy focus bar with white focused text while keeping unfocused text navy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f926bed6dc8323a163d9255a1c3571